### PR TITLE
Fix base passing while iterating

### DIFF
--- a/lib/summary.js
+++ b/lib/summary.js
@@ -54,7 +54,7 @@ function normalizeChapters(chapterList, options, level, base) {
             path: chapter.path,
             title: chapter.title.trim(),
             level: chapter.level,
-            articles: normalizeChapters(chapter.articles || [], options, chapter.level, 1),
+            articles: normalizeChapters(chapter.articles || [], options, chapter.level, i),
             exists: chapter.exists,
             external: chapter.external,
             introduction: chapter.path == options.entryPoint


### PR DESCRIPTION
While iterating the level (base) should be passed as a variable instead of a constant.